### PR TITLE
Reduce screen jitter

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -100,3 +100,4 @@ quit={
 
 textures/canvas_textures/default_texture_filter=0
 renderer/rendering_method="mobile"
+rendering/2d/snapping/use_pixel_snap=true

--- a/scenes/player/player.tscn
+++ b/scenes/player/player.tscn
@@ -521,7 +521,7 @@ shape = SubResource("RectangleShape2D_qek5x")
 zoom = Vector2(2.5, 2.5)
 limit_left = -217
 limit_right = 3100
-position_smoothing_enabled = true
+position_smoothing_enabled = false
 
 [node name="Area2D" type="Area2D" parent="."]
 collision_layer = 0


### PR DESCRIPTION
## Summary
- disable player camera position smoothing to avoid sub-pixel jitter
- enable project-wide 2D pixel snapping to keep tiles aligned when scaled

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69411616c87c832bacedbafd6ec2e0cf)